### PR TITLE
Removes deploy on PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,6 @@ name: Build and Deploy
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
Currently the docs page seems to rebuild whenever a PR gets posted. This will make it so that it will only re-deploy if the PR is accepted